### PR TITLE
Improved cmd parts in markdown files. Uniform style. Added links.

### DIFF
--- a/075_ObjectDetection_Yolo7/yolo_training_steps.md
+++ b/075_ObjectDetection_Yolo7/yolo_training_steps.md
@@ -1,36 +1,43 @@
 # Training
 
-1. get YOLO project
+## 1. Get YOLO project
 
-git clone https://github.com/WongKinYiu/yolov7.git
+```
+(pytorch) C:\...> git clone https://github.com/WongKinYiu/yolov7.git
+```
 
-2. get weights and store in yolov7 folder
+## 2. Get weights and store in yolov7 folder
 
-wget https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7-e6e.pt
+```
+(pytorch) C:\...> wget https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7-e6e.pt
+```
 
-3. adapt cfg file
+## 3. Adapt cfg file
 
-create copy of yolov7\cfg\training\yolov7-e6e.yaml
-set number of classes
+- Create copy of yolov7\cfg\training\yolov7-e6e.yaml
+- Set number of classes
 
-4. adapt data file
+## 4. Adapt data file
 
-under data/masks.yaml
+Under data/masks.yaml
 
-5. Get raw images and labels
+## 5. Get raw images and labels
 
-download from Kaggle
-source: https://www.kaggle.com/datasets/andrewmvd/face-mask-detection
+Download from Kaggle [here](https://www.kaggle.com/datasets/andrewmvd/face-mask-detection).
 
-6. Data Prep 
+## 6. Data prep 
 
 - Convert Pascal Voc labels to Yolo format
-- split data into subfolders
+- Split data into subfolders
 
-7. perform training
+## 7. Perform training
 
-python train.py --weights yolov7-e6e.pt --data data/masks.yaml --workers 1 --batch-size 4 --img 416 --cfg cfg/training/yolov7-masks.yaml --name yolov7 --epochs 5
+```
+(pytorch) C:\...> python train.py --weights yolov7-e6e.pt --data data/masks.yaml --workers 1 --batch-size 4 --img 416 --cfg cfg/training/yolov7-masks.yaml --name yolov7 --epochs 5
+```
 
-8. Detection
+## 8. Detection
 
-python detect.py --weights runs/train/yolov7/weights/best.pt 	--conf 0.4 --img-size 640 --source ./test/images/maksssksksss824.png
+```
+(pytorch) C:\...> python detect.py --weights runs/train/yolov7/weights/best.pt --conf 0.4 --img-size 640 --source ./test/images/maksssksksss824.png
+```

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # PytorchUltimate
 
-This repo holds material for the Udemy course "PyTorch Ultimate"
-
-You can find the course under this link.
+This repo holds material for the Udemy course _**PyTorch Ultimate: From Basics to Cutting-Edge**_. You can find the course under [this link](https://www.udemy.com/course/pytorch-ultimate/).
 
 ## Environment Installation from yml file
 
-We work with anaconda and use conda environments. You can replicate my environment by running:
+We work with [Anaconda](https://www.anaconda.com/) and use [conda environments](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#). You can replicate my environment by running:
 
-conda env create -f pytorch.yml
+```
+C:\...> conda env create -f pytorch.yml
+```
 
 ## Environment Installation from scratch
 
-If the installation from yml file fails, you can install the environment manually by running these commands.
+If the installation from yml file fails, you can install the environment manually by running these commands:
 
-conda create -n pytorch python=3.10
-conda activate pytorch
-conda install pytorch torchvision torchaudio cpuonly -c pytorch
-conda install ipykernel
-conda install -c anaconda seaborn
-conda install scikit-learn
-conda install -c conda-forge detecto
+```
+C:\...> conda create -n pytorch python=3.10
+C:\...> conda activate pytorch
+(pytorch) C:\...> conda install pytorch torchvision torchaudio cpuonly -c pytorch
+(pytorch) C:\...> conda install ipykernel
+(pytorch) C:\...> conda install -c anaconda seaborn
+(pytorch) C:\...> conda install scikit-learn
+(pytorch) C:\...> $ conda install -c conda-forge detecto
+```


### PR DESCRIPTION
## Hyperlinks

I have added hyperlinks to avoid the complete web direction. In markdown this is done like this: `[keyword](www.web-direction.com)`

## Capital letters

Unified style with capital letters.

## Code/cmd style

Single `accent for inline`. 

```
Triple for a section.
```

This accent "`" at the beginning and the end. You can highlight the code if you decorate with the language:

```python
import os
import numpy as np

def sin2(x):
    return np.sin(2 * x)

x = np.arange(10)
y = sin2(x)
```

This is the raw text before rendering:
![image](https://user-images.githubusercontent.com/65964377/213817458-d0f76ae5-110b-4756-997b-e4022c602565.png)


It has been a pleasure to learn PyTorch with this course!!